### PR TITLE
[Optimisation, KEY-99] moved state changes to before external calls

### DIFF
--- a/contracts/StakedAccess.sol
+++ b/contracts/StakedAccess.sol
@@ -140,8 +140,8 @@ contract StakedAccess is Ownable {
         senderCanAfford()
         senderHasApprovedTransfer()
     {
-        token.transferFrom(msg.sender, this, price);
         balances[msg.sender] = price;
+        token.transferFrom(msg.sender, this, price);
         KEYStaked(msg.sender, price);
     }
 
@@ -154,8 +154,8 @@ contract StakedAccess is Ownable {
         senderHasStaked()
     {
         uint amount = balances[msg.sender];
-        token.transfer(msg.sender, amount);
         balances[msg.sender] = 0;
+        token.transfer(msg.sender, amount);
         KEYRetrieved(msg.sender, amount);
     }
 

--- a/contracts/mocks/MockKey.sol
+++ b/contracts/mocks/MockKey.sol
@@ -17,7 +17,7 @@ contract MockKEY is StandardToken {
      *  @param amount — the amount of tokens to give.
      */
     function freeMoney(address punter, uint amount) external {
-        require(punter != 0x0);
+        require(punter != address(0));
         balances[punter] = amount;
     }
 }


### PR DESCRIPTION
also standardised on using `address(0)` over `0x0`
