### PR TITLE
[Feature, KEY-102] Each sender has a different timeout count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ jspm_packages/
 build
 
 .DS_Store
+
+wallet.json
+local/

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -3,9 +3,9 @@ const StakedAccess = artifacts.require('./StakedAccess.sol')
 module.exports = deployer => {
   const now = new Date().getTime() / 1000
 
-  const expiry = now + 2592000 // 30 days after start
   const price = 10000000000000000000 // 10 KEY
   const tokenAddress = '0x4cc19356f2d37338b9802aa8e8fc58b0373296e7' // Mainnet SelfKey Token
+  const period = 2592000 // 30 days
 
-  deployer.deploy(StakedAccess, expiry, price, tokenAddress)
+  deployer.deploy(StakedAccess, price, tokenAddress, period)
 }

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -5,7 +5,7 @@ module.exports = deployer => {
 
   const expiry = now + 2592000 // 30 days after start
   const price = 10000000000000000000 // 10 KEY
-  const tokenAddress = '0x29dc722b24a08ba7ed602219574a8b041fde92fc' // ropsten test
+  const tokenAddress = '0x4cc19356f2d37338b9802aa8e8fc58b0373296e7' // Mainnet SelfKey Token
 
   deployer.deploy(StakedAccess, expiry, price, tokenAddress)
 }

--- a/test/creation/StakedAccess_test.js
+++ b/test/creation/StakedAccess_test.js
@@ -1,12 +1,11 @@
 const assertThrows = require('../utils/assertThrows')
-const { makeTime } = require('../utils/fakes')
 
 const MockKey = artifacts.require('./mocks/MockKEY.sol')
 const StakedAccess = artifacts.require('./StakedAccess.sol')
 
 contract('StakedAccess (creation)', ([owner]) => {
-  const price = 10
-  const expiry = makeTime()
+  const price = 10000000000000000000 // 10 KEY
+  const period = 2592000 // 30 days
 
   let token
 
@@ -18,7 +17,7 @@ contract('StakedAccess (creation)', ([owner]) => {
     let escrow
 
     before(async () => {
-      escrow = await StakedAccess.new(expiry, price, token.address)
+      escrow = await StakedAccess.new(price, token.address, period)
     })
 
     it('created the contract', () => {
@@ -32,13 +31,13 @@ contract('StakedAccess (creation)', ([owner]) => {
   })
 
   context('given invalid parameters', () => {
-    it('will not create a contract with an invalid date', async () =>
-      assertThrows(StakedAccess.new(makeTime(-100), price, token.address)))
-
     it('will not create a contract with an invalid price', async () =>
-      assertThrows(StakedAccess.new(expiry, 0, token.address)))
+      assertThrows(StakedAccess.new(0, token.address, period)))
 
     it('will not create a contract with an invalid token address', async () =>
-      assertThrows(StakedAccess.new(expiry, price, '0x0')))
+      assertThrows(StakedAccess.new(price, '0x0', period)))
+
+    it('will not create a contract with an invalid staking period', async () =>
+      assertThrows(StakedAccess.new(price, token.address, 0)))
   })
 })

--- a/test/utils/fakes.js
+++ b/test/utils/fakes.js
@@ -1,8 +1,0 @@
-const TWENTY_DAYS = 20 * 24 * 60 * 60
-
-const makeTime = (days = TWENTY_DAYS) =>
-  Math.floor(new Date().getTime() / 1000) + days
-
-module.exports = {
-  makeTime
-}


### PR DESCRIPTION
A `releaseDates` mapping was added to keep track of each release date for each different sender. Contract has no global `expiry` now.