### PR TITLE
[Feature, KEY-104] Staking period can be changed by owner

### DIFF
--- a/contracts/StakedAccess.sol
+++ b/contracts/StakedAccess.sol
@@ -21,7 +21,7 @@ contract StakedAccess is Ownable {
     uint256 public price;
 
     // the MINIMUM time a staking should be done before allowing release by sender
-    uint256 public stakePeriod;
+    uint256 public period;
 
     // the ERC20 token this contract will receive as stake
     ERC20 private token;
@@ -98,7 +98,7 @@ contract StakedAccess is Ownable {
 
         price = _price;
         token = ERC20(_token);
-        stakePeriod = _period;
+        period = _period;
     }
 
     /**
@@ -113,6 +113,17 @@ contract StakedAccess is Ownable {
     }
 
     /**
+     *  Owner can change the minimum staking period. Time should be in UNIX format.
+     *  Stakes previously made are not affected.
+     *  @param _period - New period to set for all future stakes
+     */
+    function setPeriod(uint256 _period) onlyOwner public {
+        require(_period > 0);
+
+        period = _period;
+    }
+
+    /**
      *  Stake `price` amount of `KEY`.
      */
     function stake()
@@ -122,7 +133,7 @@ contract StakedAccess is Ownable {
         senderHasApprovedTransfer()
     {
         balances[msg.sender] = price;
-        releaseDates[msg.sender] = now + stakePeriod;
+        releaseDates[msg.sender] = now + period;
         token.safeTransferFrom(msg.sender, this, price);
 
         KEYStaked(msg.sender, price);

--- a/test/interactions/StakedAccess-staking_test.js
+++ b/test/interactions/StakedAccess-staking_test.js
@@ -74,16 +74,33 @@ contract('StakedAccess (interactions)', accounts => {
     it('can change the price', async () => {
       const newPrice = 234234999
       await escrow.setPrice(newPrice, { from: owner })
-      const contractPrice = await escrow.price.call()
+      let contractPrice = await escrow.price.call()
       assert.equal(contractPrice.toNumber(), newPrice)
 
       // Revert to old price
       await escrow.setPrice(price, { from: owner })
+      contractPrice = await escrow.price.call()
+      assert.equal(contractPrice.toNumber(), price)
+    })
+
+    it('can change the staking period', async () => {
+      const newPeriod = 999999
+      await escrow.setPeriod(newPeriod, { from: owner })
+      let contractPeriod = await escrow.period.call()
+      assert.equal(contractPeriod.toNumber(), newPeriod)
+
+      // Revert to old price
+      await escrow.setPeriod(period, { from: owner })
+      contractPeriod = await escrow.period.call()
+      assert.equal(contractPeriod.toNumber(), period)
     })
   })
 
   context('not owner', () => {
     it('cannot change the price', () =>
       assertThrows(escrow.setPrice(999999, { from: sender })))
+
+    it('cannot change the staking period', () =>
+      assertThrows(escrow.setPeriod(7, { from: sender })))
   })
 })


### PR DESCRIPTION
Contract owner can change the staking period for new deposits. This does not affect previous stakes.