### PR TITLE
[Documentation, KEY-107] Added StakedAccess contract specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,60 @@ Contracts that provide access to a marketplace based on the staking of KEY by pa
 
 ## Overview
 
-Many ICOs require that their participants be KYC (Know Your Customer) verified before being allowed to participate in their crowdsale.
-
 The `StakedAccess` contracts by the SelfKeyFoundation provide the following functionality.
 
-1. Addresses are able to `stake` `KEY` tokens, reserving an amount of tokens to indicate their willingness to participate in an ICO.
-2. Staked `KEY` can only be retrieved by its owner once the `StakedAccess` contract has expired.
+1. Addresses are able to "stake" _KEY_ into a smart contract, reserving an amount of tokens to
+indicate their willingness to participate in a particular Selfkey Marketplace. The tokens staked in
+this manner are kept "locked" for a set amount of time defined by the `period` attribute in the `StakedAccess` contract.
+
+2. Staked tokens can only be retrieved by the owner once the staking period has passed.
+
+3. For the staking functionality to work, owner (or ID-Wallet in our specific case) has to invoke `approve(stakingContractAddress, stakingPrice)` against on the **token contract**, passing the
+staking contract address and the corresponding staking price (including all decimal places). This is
+to allow the staking contract to spend funds (up to the limit set) on behalf of its owner.
+
+### StakedAccess contract
+
+All staking functionality is implemented by the `StakedAccess` contract, which includes the
+following attributes:
+
+#### Public state Variables
+
+`releaseDates`: A mapping from addresses to a datetime in Unix format, stating the moment at which
+the staking can be released.
+
+`price`: The token amount to be staked. This number should include all 18 decimals (e.g. for a
+  staking price of 30 _KEY_, `price`  should be set to 30000000000000000000).
+
+`period`: The minimum amount of _seconds_ that each stake should be locked for before allowing
+token retrieval.
+
+#### Functions
+
+`stake()`: On invoking the `stake()` function, an mount of tokens defined by `price` will be
+deducted from the sender address balance, and be kept locked in the staking contract until the
+due staking period has been fulfilled. For the contract to be able to deduct tokens on behalf of
+the user, the user **must previously call the approve method of the token contract.**
+
+`retrieve()`: If the corresponding release date for the sender has already been reached, the sender
+can invoke the `retrieve()` function, in which case the staked amount is sent back to the owner
+wallet.
+
+`hasStake(address)`: returns true if the given address has a stake above zero on the contract, otherwise it returns false.
+
+`setPrice(uint)` (**only owner**): Staking price can be changed anytime by the contract
+owner.
+
+`setPeriod(uint)` (**only owner**): Staking period can be changed anytime by the contract
+owner. This won't affect the release date of stakes already in place.
+
+#### Events
+
+`KEYStaked(address by, uint amount)`: Emitted when an address has successfully staked an amount of
+_KEY_.
+
+`KEYRetrieved(address to, uint amount)`: Emitted when a _KEY_ owner has released the tokens
+previously staked.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Contracts that provide access to a marketplace based on the staking of KEY by pa
 
 ## Overview
 
-The `StakedAccess` contracts by the SelfKeyFoundation provide the following functionality.
+The `StakedAccess` contract provides the following functionality.
 
 1. Addresses are able to "stake" _KEY_ into a smart contract, reserving an amount of tokens to
 indicate their willingness to participate in a particular Selfkey Marketplace. The tokens staked in
@@ -21,12 +21,12 @@ this manner are kept "locked" for a set amount of time defined by the `period` a
 staking contract address and the corresponding staking price (including all decimal places). This is
 to allow the staking contract to spend funds (up to the limit set) on behalf of its owner.
 
-### StakedAccess contract
+### StakedAccess Contract Interface
 
 All staking functionality is implemented by the `StakedAccess` contract, which includes the
 following attributes:
 
-#### Public state Variables
+#### Public State Variables
 
 `releaseDates`: A mapping from addresses to a datetime in Unix format, stating the moment at which
 the staking can be released.
@@ -37,7 +37,7 @@ the staking can be released.
 `period`: The minimum amount of _seconds_ that each stake should be locked for before allowing
 token retrieval.
 
-#### Functions
+#### Public Functions
 
 `stake()`: On invoking the `stake()` function, an mount of tokens defined by `price` will be
 deducted from the sender address balance, and be kept locked in the staking contract until the
@@ -74,7 +74,7 @@ The smart contracts are being implemented in Solidity `0.4.19`.
 * [truffle](http://truffleframework.com/), which is a comprehensive framework for Ethereum development. `npm install -g truffle` — this should install Truffle v4+.  Check that with `truffle version`.
 * [Access to the KYC_Chain Jira](https://kyc-chain.atlassian.net)
 
-### Initialisation
+### Initialization
 
     npm install
 
@@ -113,7 +113,7 @@ We provide the following linting options
 
 Deploy the contracts as follows
 
-_Carlos to complete_
+**(TO DO)**
 
 ## Contributing
 


### PR DESCRIPTION
Added specification for staking contract public variables and functions on the _Overview_ section of the `README.md` file.